### PR TITLE
Attach SSL certificate to Kong

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 **.DS_Store
 
+**.crt 
+**.ca-bundle
+**.key
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/backend/api_gateway/kong/Dockerfile
+++ b/backend/api_gateway/kong/Dockerfile
@@ -5,6 +5,7 @@ ENV KONG_PLUGINS=authentication_plugin
 
 COPY kong.yml /
 COPY ./authentication_plugin /usr/local/share/lua/5.1/kong/plugins/authentication_plugin
+COPY certs /etc/kong/ssl
 
 USER kong
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -42,6 +42,8 @@ services:
       KONG_ADMIN_LISTEN: 0.0.0.0:8001
       KONG_ADMIN_GUI_URL: http://localhost:8002
       KONG_PLUGINS: rate-limiting,authentication_plugin
+      KONG_SSL_CERT: /etc/kong/ssl/kong.ca-bundle
+      KONG_SSL_CERT_KEY: /etc/kong/ssl/kong.key
     ports:
       - "80:8000"
       - "8443:8443"

--- a/backend/kubernetes/kong/kong-deployment.yaml
+++ b/backend/kubernetes/kong/kong-deployment.yaml
@@ -44,6 +44,10 @@ spec:
               value: /dev/stderr
             - name: KONG_PLUGINS
               value: rate-limiting,authentication_plugin
+            - name: KONG_SSL_CERT
+              value: /etc/kong/ssl/kong.ca-bundle
+            - name: KONG_SSL_CERT_KEY
+              value: /etc/kong/ssl/kong.key
           image: asia-southeast1-docker.pkg.dev/${GCP_PROJECT_ID}/gobbler/kong:latest
           name: kong
           ports:
@@ -61,5 +65,12 @@ spec:
           #     path: /
           #     port: 8000
           #   initialDelaySeconds: 120
+          volumeMounts:
+            - mountPath: /etc/kong/ssl
+              name: kong-ssl-cert-files
       restartPolicy: Always
+      volumes:
+        - name: kong-ssl-cert-files
+          secret:
+            secretName: kong-ssl-cert
 status: {}

--- a/backend/kubernetes/kong/kong-service.yaml
+++ b/backend/kubernetes/kong/kong-service.yaml
@@ -16,9 +16,6 @@ spec:
       targetPort: 8000
     - name: "https"
       port: 443
-      targetPort: 8000
-    - name: "8443"
-      port: 8443
       targetPort: 8443
     - name: "8001"
       port: 8001


### PR DESCRIPTION
Use Kubernetes secrets to mount ca certificate and private key to Kong API Gateway for HTTPS connection to port 8443. Reroute port 443 traffic to 8443 on the pod