### PR TITLE
Extend access token duration ttl to 10 minnutes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
           token_format: access_token
           workload_identity_provider: ${{ secrets.GCP_IAM_PROVIDER_ID }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          access_token_lifetime: 300s
+          access_token_lifetime: 600s
 
       - name: Login to Artifact Registry
         uses: docker/login-action@v1


### PR DESCRIPTION
Docker compose build in CI seems to keep failing at 5 minutes, trying extension of timeout to 10 minutes to check fix
* Fix is in extending access token TTL from 5 minutes to 10 minutes